### PR TITLE
Increase size of project avatar

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -111,7 +111,7 @@ export class JiraAPI {
     return {
       project: {
         name: project.name,
-        iconUrl: project.avatarUrls['16x16'],
+        iconUrl: project.avatarUrls['48x48'],
         type: project.projectTypeKey,
         url: this.generateProjectUrl(project.self),
       },


### PR DESCRIPTION
Increases the size of the project avatar.  Currently it's only used to display inline with the card subtitle, which is roughly 40 pixels or so, so bump the icon up to the highest. I just noticed my project's card icon was blurry since it was the lowest rez but was being scaled up.