### PR TITLE
Support complex multi-word components

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -74,7 +74,7 @@ export class JiraAPI {
       project = "${projectKey}"
       AND issuetype = "${issueType}"
       ${statusesString ? `AND status in (${statusesString})` : ''}
-      ${component ? `AND component = ${component}` : ''}
+      ${component ? `AND component = "${component}"` : ''}
     `;
     const data = {
       jql,


### PR DESCRIPTION
My team uses some complex components which are multiple words, e.g. "Release Pipeline".

Currently, with a two word component the generated plugin JQL returned:

![image](https://user-images.githubusercontent.com/33203301/100534820-04087d80-31e1-11eb-9aa0-4501224fd8ab.png)

By wrapping quotes around the component, we can support multiple word components. Tested locally and worked for me.
