### PR TITLE
Fix: filter statuses by project

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ import {
 } from '@roadiehq/backstage-plugin-jira';
 
 const OverviewContent = ({ entity }: { entity: Entity }) => (
-
   <Grid container spacing={3} alignItems="stretch">
     ...
     {isJiraAvailable(entity) && (

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -128,9 +128,9 @@ export class JiraAPI {
     return activityStream; 
   }
 
-  async getStatuses() {
+  async getStatuses(projectKey: string) {
     const { apiUrl } = await this.getUrls();
-    const request = await axios.get(`${apiUrl}status`);
+    const request = await axios.get(`${apiUrl}project/${projectKey}/statuses`);
     const statuses = request.data as Array<Status>;
     const formattedStatuses = statuses.length ? [...new Set(statuses.map((status) => status.name))] : [];
     return formattedStatuses;

--- a/src/components/JiraCard/JiraCard.tsx
+++ b/src/components/JiraCard/JiraCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { useState } from 'react';
-import { 
+import {
   Avatar,
   Box,
   Grid,
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
       '& + .MuiAlert-root': {
         marginTop: theme.spacing(3),
       },
-    },  
+    },
     root: {
       flexGrow: 1,
       fontSize: '0.75rem',
@@ -49,7 +49,10 @@ const useStyles = makeStyles((theme: Theme) =>
 const CardProjectDetails = ({ project }: { project: ProjectDetailsProps }) => (
   <Box display="flex" alignItems="center">
     <Avatar alt="" src={project.iconUrl} />
-    <Box component="span" ml={1}> {project.name} | {project.type}</Box>
+    <Box component="span" ml={1}>
+      {' '}
+      {project.name} | {project.type}
+    </Box>
   </Box>
 );
 
@@ -57,35 +60,51 @@ export const JiraCard = ({ entity }: EntityProps) => {
   const classes = useStyles();
   const { projectKey, component } = useProjectEntity(entity);
   const [statusesNames, setStatusesNames] = useState<Array<string>>([]);
-  const { project, issues, projectLoading, projectError, fetchProjectInfo } = useProjectInfo(projectKey, component, statusesNames);
+  const {
+    project,
+    issues,
+    projectLoading,
+    projectError,
+    fetchProjectInfo,
+  } = useProjectInfo(projectKey, component, statusesNames);
 
   return (
     <InfoCard
       title="Jira"
-      subheader= { project && <CardProjectDetails project={ project }/> }
+      subheader={project && <CardProjectDetails project={project} />}
       className={classes.infoCard}
       deepLink={{
         link: `${project?.url}/browse/${projectKey}`,
         title: 'Go to project',
-        onClick: (e) => {
+        onClick: e => {
           e.preventDefault();
           window.open(`${project?.url}/browse/${projectKey}`);
-        }
+        },
       }}
     >
-      { projectLoading && !(project && issues) ? <Progress /> : null }
-      { projectError ? <Alert severity="error" className={classes.infoCard}>{projectError.message}</Alert> : null }
-      { project && issues ? (
+      {projectLoading && !(project && issues) ? <Progress /> : null}
+      {projectError ? (
+        <Alert severity="error" className={classes.infoCard}>
+          {projectError.message}
+        </Alert>
+      ) : null}
+      {project && issues ? (
         <div className={classes.root}>
           <Grid container spacing={3}>
-            { issues.map(issueType => (
+            {issues.map(issueType => (
               <Grid item xs key={issueType.name}>
-                <Box width={ 100 } display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+                <Box
+                  width={100}
+                  display="flex"
+                  flexDirection="column"
+                  alignItems="center"
+                  justifyContent="center"
+                >
                   <Status name={issueType.name} iconUrl={issueType.iconUrl} />
                   <Typography variant="h4">{issueType.total}</Typography>
                 </Box>
               </Grid>
-            )) }
+            ))}
           </Grid>
           <Selectors
             projectKey={projectKey}
@@ -95,7 +114,7 @@ export const JiraCard = ({ entity }: EntityProps) => {
           />
           <ActivityStream />
         </div>
-      ) : null }
+      ) : null}
     </InfoCard>
   );
 };

--- a/src/components/JiraCard/JiraCard.tsx
+++ b/src/components/JiraCard/JiraCard.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState, FC } from 'react';
+import React, { useState } from 'react';
 import { 
   Avatar,
   Box,
@@ -53,7 +53,7 @@ const CardProjectDetails = ({ project }: { project: ProjectDetailsProps }) => (
   </Box>
 );
 
-export const JiraCard: FC<EntityProps> = ({ entity }) => {
+export const JiraCard = ({ entity }: EntityProps) => {
   const classes = useStyles();
   const { projectKey, component } = useProjectEntity(entity);
   const [statusesNames, setStatusesNames] = useState<Array<string>>([]);
@@ -88,6 +88,7 @@ export const JiraCard: FC<EntityProps> = ({ entity }) => {
             )) }
           </Grid>
           <Selectors
+            projectKey={projectKey}
             statusesNames={statusesNames}
             setStatusesNames={setStatusesNames}
             fetchProjectInfo={fetchProjectInfo}

--- a/src/components/JiraCard/components/ActivityStream.tsx
+++ b/src/components/JiraCard/components/ActivityStream.tsx
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 import React, { useState, useCallback } from 'react';
-import { Box, Divider, Link, Paper, Typography, Tooltip, makeStyles, createStyles, Theme, } from '@material-ui/core';
+import {
+  Box,
+  Divider,
+  Link,
+  Paper,
+  Typography,
+  Tooltip,
+  makeStyles,
+  createStyles,
+  Theme,
+} from '@material-ui/core';
 import { Progress } from '@backstage/core';
-import parse, { domToReact, attributesToProps, DomElement } from 'html-react-parser';
+import parse, {
+  domToReact,
+  attributesToProps,
+  DomElement,
+} from 'html-react-parser';
 import { useActivityStream } from '../../../hooks';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -36,13 +50,13 @@ const useStyles = makeStyles((theme: Theme) =>
         margin: theme.spacing(1, 0),
       },
       '& blockquote': {
-        background: theme.palette.type === 'dark' ? '#424242' : "#e0f0ff",
-        borderLeft: "1px solid #c2d9ef",
+        background: theme.palette.type === 'dark' ? '#424242' : '#e0f0ff',
+        borderLeft: '1px solid #c2d9ef',
         color: theme.palette.text.primary,
-        fontStyle: "normal",
+        fontStyle: 'normal',
         margin: theme.spacing(1, 0),
-        overflowX: "auto",
-        overflowY: "hidden",
+        overflowX: 'auto',
+        overflowY: 'hidden',
         padding: theme.spacing(0, 1),
       },
       '& > :last-child > hr': {
@@ -58,13 +72,15 @@ const useStyles = makeStyles((theme: Theme) =>
         borderRadius: '5px',
       },
       '&::-webkit-scrollbar-thumb': {
-        border: `1px solid ${theme.palette.type === 'dark' ? '#555' : '#F5F5F5'}`,
-        backgroundColor: theme.palette.type === 'dark' ? '#F5F5F5': '#555',
+        border: `1px solid ${
+          theme.palette.type === 'dark' ? '#555' : '#F5F5F5'
+        }`,
+        backgroundColor: theme.palette.type === 'dark' ? '#F5F5F5' : '#555',
         borderRadius: '4px',
       },
       '& span': {
         fontSize: '0.7rem',
-      }
+      },
     },
     time: {
       lineHeight: 0,
@@ -79,69 +95,77 @@ const useStyles = makeStyles((theme: Theme) =>
 const options = {
   replace: (node: DomElement) => {
     if (!node) return null;
- 
-    if (node.name === 'a') { // Add target blank to all urls
-      const props = attributesToProps(node.attribs as {[key: string]: string});
-      return <a {...props} target="_blank" rel="noopener noreferrer">{node.children && domToReact(node.children)}</a>;
+
+    if (node.name === 'a') {
+      // Add target blank to all urls
+      const props = attributesToProps(
+        node.attribs as { [key: string]: string },
+      );
+      return (
+        <a {...props} target="_blank" rel="noopener noreferrer">
+          {node.children && domToReact(node.children)}
+        </a>
+      );
     }
     return null;
-  }
+  },
 };
 
 export const ActivityStream = () => {
   const classes = useStyles();
   const [size, setSize] = useState(25);
   const [disableButton, setDisableButton] = useState(false);
-  const { activities, activitiesLoading, activitiesError } = useActivityStream(size);
+  const { activities, activitiesLoading, activitiesError } = useActivityStream(
+    size,
+  );
 
   const showMore = useCallback(() => {
     setSize(size + 10);
-    if(activities && activities.length < size) {
+    if (activities && activities.length < size) {
       setDisableButton(true);
     }
   }, [size, activities]);
 
-
-  if(activitiesError) return null; // Hide activity stream on error
+  if (activitiesError) return null; // Hide activity stream on error
 
   return (
     <>
       <Typography variant="subtitle1">Activity stream</Typography>
       <Paper className={classes.paper}>
-      { activitiesLoading ? <Progress /> : null }
-      { activities ? (
-        <>
-        {activities.map(entry => (
-          <Box key={entry.id}>
-            {parse(entry.title, options)} 
-            <Box>
-              {parse((entry.summary || entry.content || ''), options)}
+        {activitiesLoading ? <Progress /> : null}
+        {activities ? (
+          <>
+            {activities.map(entry => (
+              <Box key={entry.id}>
+                {parse(entry.title, options)}
+                <Box>
+                  {parse(entry.summary || entry.content || '', options)}
+                </Box>
+                <Box display="flex" alignItems="center" mt={1}>
+                  <Tooltip title={entry.icon.title}>
+                    <img src={entry.icon.url} alt={entry.icon.title} />
+                  </Tooltip>
+                  <Tooltip title={entry.time.value}>
+                    <Typography variant="caption" className={classes.time}>
+                      {entry.time.elapsed}
+                    </Typography>
+                  </Tooltip>
+                </Box>
+                <Divider />
+              </Box>
+            ))}
+            <Box display="flex" justifyContent="center" pt={1}>
+              {disableButton ? (
+                'No more activities'
+              ) : (
+                <Link onClick={showMore} className={classes.link}>
+                  {activitiesLoading ? 'Loading..' : 'Show more..'}
+                </Link>
+              )}
             </Box>
-            <Box display="flex" alignItems="center" mt={1}>
-              <Tooltip title={entry.icon.title}>
-                <img src={entry.icon.url} alt={entry.icon.title} />
-              </Tooltip>
-              <Tooltip title={entry.time.value}>
-                <Typography variant="caption" className={classes.time}>
-                    {entry.time.elapsed}
-                </Typography>
-              </Tooltip>
-            </Box>
-            <Divider />
-          </Box>
-        ))}
-        <Box display="flex" justifyContent="center" pt={1}>
-          {disableButton ? (
-              'No more activities'
-          ) : (
-            <Link onClick={showMore} className={classes.link}>
-              {activitiesLoading ? 'Loading..' : 'Show more..'}
-          </Link>
-          )}
-        </Box>
-        </>
-      ) : null }
+          </>
+        ) : null}
       </Paper>
     </>
   );
-}
+};

--- a/src/components/JiraCard/components/Selectors.tsx
+++ b/src/components/JiraCard/components/Selectors.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC } from 'react';
+import React from 'react';
 import { 
   Box,
   Checkbox,
@@ -52,13 +52,14 @@ const MenuProps = {
   },
 };
 
-export const Selectors: FC<SelectorsProps> = ({
+export const Selectors = ({
+  projectKey,
   statusesNames,
   setStatusesNames,
   fetchProjectInfo,
-}) => {
+} : SelectorsProps ) => {
   const classes = useStyles();
-  const { statuses, statusesLoading, statusesError } = useStatuses();
+  const { statuses, statusesLoading, statusesError } = useStatuses(projectKey);
 
   const handleStatusesChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setStatusesNames(event.target.value as string[]);

--- a/src/components/JiraCard/components/Selectors.tsx
+++ b/src/components/JiraCard/components/Selectors.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { 
+import {
   Box,
   Checkbox,
   Divider,
@@ -57,21 +57,28 @@ export const Selectors = ({
   statusesNames,
   setStatusesNames,
   fetchProjectInfo,
-} : SelectorsProps ) => {
+}: SelectorsProps) => {
   const classes = useStyles();
   const { statuses, statusesLoading, statusesError } = useStatuses(projectKey);
 
-  const handleStatusesChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+  const handleStatusesChange = (
+    event: React.ChangeEvent<{ value: unknown }>,
+  ) => {
     setStatusesNames(event.target.value as string[]);
   };
 
   // Show selector only when needed
-  return !statusesLoading && !statusesError && statuses && statuses.length >= 2 ? (
+  return !statusesLoading &&
+    !statusesError &&
+    statuses &&
+    statuses.length >= 2 ? (
     <Box py={2}>
       <Divider />
       <Box display="flex" justifyContent="flex-end" py={2}>
         <FormControl className={classes.formControl}>
-          <InputLabel id="select-multiple-projects-statuses">Statuses</InputLabel>
+          <InputLabel id="select-multiple-projects-statuses">
+            Statuses
+          </InputLabel>
           <Select
             labelId="select-statuses-label"
             id="select-statuses"
@@ -79,11 +86,13 @@ export const Selectors = ({
             value={statusesNames}
             onChange={handleStatusesChange}
             input={<Input />}
-            renderValue={(selected) => (selected as Array<string>).filter(Boolean).join(', ')}
+            renderValue={selected =>
+              (selected as Array<string>).filter(Boolean).join(', ')
+            }
             MenuProps={MenuProps}
             onClose={fetchProjectInfo}
           >
-            {statuses.map((status) => (
+            {statuses.map(status => (
               <MenuItem key={status} value={status}>
                 <Checkbox checked={statusesNames.indexOf(status) > -1} />
                 <ListItemText primary={status} />

--- a/src/components/JiraCard/components/Status.tsx
+++ b/src/components/JiraCard/components/Status.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Box, Typography, makeStyles, createStyles, } from '@material-ui/core';
+import { Box, Typography, makeStyles, createStyles } from '@material-ui/core';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -24,7 +24,13 @@ const useStyles = makeStyles(() =>
   }),
 );
 
-export const Status = ({name, iconUrl} : {name: string, iconUrl: string}) => {
+export const Status = ({
+  name,
+  iconUrl,
+}: {
+  name: string;
+  iconUrl: string;
+}) => {
   const classes = useStyles();
   return (
     <Box display="flex" alignItems="center" justifyContent="center" mb={1}>

--- a/src/components/JiraCard/index.ts
+++ b/src/components/JiraCard/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { JiraCard} from './JiraCard';
+export { JiraCard } from './JiraCard';

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -19,4 +19,3 @@ import { JIRA_PROJECT_KEY_ANNOTATION } from '../hooks';
 
 export const isPluginApplicableToEntity = (entity: Entity) =>
   entity?.metadata.annotations?.[JIRA_PROJECT_KEY_ANNOTATION];
-

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -17,4 +17,7 @@
 export { useActivityStream } from './useActivityStream';
 export { useProjectInfo } from './useProjectInfo';
 export { useStatuses } from './useStatuses';
-export { useProjectEntity, JIRA_PROJECT_KEY_ANNOTATION } from './useProjectEntity';
+export {
+  useProjectEntity,
+  JIRA_PROJECT_KEY_ANNOTATION,
+} from './useProjectEntity';

--- a/src/hooks/useActivityStream.ts
+++ b/src/hooks/useActivityStream.ts
@@ -17,15 +17,22 @@ import { useEffect, useCallback } from 'react';
 import convert from 'xml-js';
 import moment from 'moment';
 import { useApi } from '@backstage/core';
-import { useAsyncFn} from 'react-use';
+import { useAsyncFn } from 'react-use';
 import { handleError } from './utils';
-import { ActivityStreamEntry, ActivityStreamElement, ActivityStreamKeys } from '../types';
+import {
+  ActivityStreamEntry,
+  ActivityStreamElement,
+  ActivityStreamKeys,
+} from '../types';
 import { jiraApiRef } from '../api';
 
-const getPropertyValue = (entry: ActivityStreamEntry, property: ActivityStreamKeys): string => entry[property]?._text;
+const getPropertyValue = (
+  entry: ActivityStreamEntry,
+  property: ActivityStreamKeys,
+): string => entry[property]?._text;
 const getElapsedTime = (start: string) => moment(start).fromNow();
 const decodeHtml = (html: string) => {
-  const txt = document.createElement("textarea");
+  const txt = document.createElement('textarea');
   txt.innerHTML = html;
   return txt.value;
 };
@@ -36,32 +43,43 @@ export const useActivityStream = (size: number) => {
   const getActivityStream = useCallback(async () => {
     try {
       const response = await api.getActivityStream(size);
-      const parsedData = JSON.parse(convert.xml2json(response, {compact: true, spaces: 2}));
-      const mappedData = parsedData.feed.entry.map((entry: ActivityStreamEntry): ActivityStreamElement => {
-        const time = getPropertyValue(entry, 'updated');
-        const icon = entry.link[1]._attributes;
-        return {
-          id: getPropertyValue(entry, 'id'),
-          time: {
-            elapsed: getElapsedTime(time),
-            value: new Date(time).toLocaleTimeString("en-US", { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
-          },
-          title: decodeHtml(getPropertyValue(entry, 'title')),
-          icon: {
-            url: icon.href,
-            title: icon.title,
-          },
-          summary: decodeHtml(getPropertyValue(entry, 'summary') || ''),
-          content: decodeHtml(getPropertyValue(entry, 'content') || ''),
-        }
-      });
+      const parsedData = JSON.parse(
+        convert.xml2json(response, { compact: true, spaces: 2 }),
+      );
+      const mappedData = parsedData.feed.entry.map(
+        (entry: ActivityStreamEntry): ActivityStreamElement => {
+          const time = getPropertyValue(entry, 'updated');
+          const icon = entry.link[1]._attributes;
+          return {
+            id: getPropertyValue(entry, 'id'),
+            time: {
+              elapsed: getElapsedTime(time),
+              value: new Date(time).toLocaleTimeString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              }),
+            },
+            title: decodeHtml(getPropertyValue(entry, 'title')),
+            icon: {
+              url: icon.href,
+              title: icon.title,
+            },
+            summary: decodeHtml(getPropertyValue(entry, 'summary') || ''),
+            content: decodeHtml(getPropertyValue(entry, 'content') || ''),
+          };
+        },
+      );
       return mappedData as Array<ActivityStreamElement>;
     } catch (err) {
       return handleError(err);
     }
   }, [api, size]);
-  
-  const [state, fetchActivityStream] = useAsyncFn(() => getActivityStream(), [size]);
+
+  const [state, fetchActivityStream] = useAsyncFn(() => getActivityStream(), [
+    size,
+  ]);
 
   useEffect(() => {
     fetchActivityStream();

--- a/src/hooks/useProjectEntity.ts
+++ b/src/hooks/useProjectEntity.ts
@@ -20,7 +20,11 @@ const JIRA_COMPONENT_ANNOTATION = 'jira/component';
 
 export const useProjectEntity = (entity: Entity) => {
   return {
-    projectKey: entity.metadata?.annotations?.[JIRA_PROJECT_KEY_ANNOTATION] as string,
-    component: entity.metadata?.annotations?.[JIRA_COMPONENT_ANNOTATION] as string,
+    projectKey: entity.metadata?.annotations?.[
+      JIRA_PROJECT_KEY_ANNOTATION
+    ] as string,
+    component: entity.metadata?.annotations?.[
+      JIRA_COMPONENT_ANNOTATION
+    ] as string,
   };
 };

--- a/src/hooks/useProjectInfo.ts
+++ b/src/hooks/useProjectInfo.ts
@@ -15,14 +15,14 @@
  */
 import { useEffect, useCallback } from 'react';
 import { useApi } from '@backstage/core';
-import { useAsyncFn} from 'react-use';
+import { useAsyncFn } from 'react-use';
 import { handleError } from './utils';
 import { jiraApiRef } from '../api';
 
 export const useProjectInfo = (
   projectKey: string,
   component: string,
-  statusesNames: Array<string>
+  statusesNames: Array<string>,
 ) => {
   const api = useApi(jiraApiRef);
 
@@ -34,13 +34,15 @@ export const useProjectInfo = (
       return handleError(err);
     }
   }, [api, projectKey, component, statusesNames]);
-  
-  const [state, fetchProjectInfo] = useAsyncFn(() => getProjectDetails(), [statusesNames]);
+
+  const [state, fetchProjectInfo] = useAsyncFn(() => getProjectDetails(), [
+    statusesNames,
+  ]);
 
   useEffect(() => {
     fetchProjectInfo();
   }, [statusesNames, fetchProjectInfo]);
-  
+
   return {
     projectLoading: state.loading,
     project: state?.value?.project,

--- a/src/hooks/useStatuses.ts
+++ b/src/hooks/useStatuses.ts
@@ -29,8 +29,8 @@ export const useStatuses = (projectKey: string) => {
       return handleError(err);
     }
   }, [api, projectKey]);
-  
-  const {loading, value, error} = useAsync(() => getStatuses(), []);
+
+  const { loading, value, error } = useAsync(() => getStatuses(), []);
   return {
     statusesLoading: loading,
     statuses: value,

--- a/src/hooks/useStatuses.ts
+++ b/src/hooks/useStatuses.ts
@@ -19,16 +19,16 @@ import { useAsync } from 'react-use';
 import { handleError } from './utils';
 import { jiraApiRef } from '../api';
 
-export const useStatuses = () => {
+export const useStatuses = (projectKey: string) => {
   const api = useApi(jiraApiRef);
 
   const getStatuses = useCallback(async () => {
     try {
-      return await api.getStatuses();
+      return await api.getStatuses(projectKey);
     } catch (err) {
       return handleError(err);
     }
-  }, [api]);
+  }, [api, projectKey]);
   
   const {loading, value, error} = useAsync(() => getStatuses(), []);
   return {

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -15,6 +15,12 @@
  */
 import { AxiosError } from 'axios';
 
-export const handleError = (error: AxiosError) => Promise.reject({
-  message: error?.response?.data?.errorMessages && error.response.data.errorMessages[0].toString() || error?.message || error?.request || error.toString(),
-});
+export const handleError = (error: AxiosError) =>
+  Promise.reject({
+    message:
+      (error?.response?.data?.errorMessages &&
+        error.response.data.errorMessages[0].toString()) ||
+      error?.message ||
+      error?.request ||
+      error.toString(),
+  });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -38,7 +38,7 @@ export const plugin = createPlugin({
           discoveryApi,
           apiVersion: configApi.getOptionalNumber('jira.apiVersion'),
         });
-      }
+      },
     }),
   ],
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,5 +107,5 @@ export type ProjectDetailsProps = {
 };
 
 export type Status = {
-  name: string;
+  statuses: Array<{ name: string }>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type EntityProps = {
 };
 
 export type SelectorsProps = {
+  projectKey: string;
   statusesNames: Array<string>;
   setStatusesNames: Dispatch<SetStateAction<Array<string>>>;
   fetchProjectInfo: () => Promise<any>;


### PR DESCRIPTION
This PR adds projectKey variable to function that fetch Statuses in order to filter them correctly per project.
Also small change was included that removes FC from plugin. 
Related issue: https://github.com/RoadieHQ/backstage-plugin-jira/issues/8