### PR TITLE
Use latest as default instead of individual numbers for apiVersion

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,7 +24,7 @@ export const jiraApiRef = createApiRef<JiraAPI>({
 });
 
 const DEFAULT_PROXY_PATH = '/jira/api';
-const DEFAULT_REST_API_VERSION = 3;
+const DEFAULT_REST_API_VERSION = 'latest';
 
 type Options = {
   discoveryApi: DiscoveryApi;


### PR DESCRIPTION
Instead of using a hard-number for the JIRA API version you should use the /latest/ resource parameter which will use the latest one present in the target JIRA. 