### PR TITLE
Add IssueType filter to the overview card

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add @roadiehq/backstage-plugin-jira
 // app-config.yaml
 proxy:
   '/jira/api':
-    target: [JIRA_URL]
+    target: <JIRA_URL>
     headers:
       Authorization:
         $env: JIRA_TOKEN
@@ -69,13 +69,13 @@ const OverviewContent = ({ entity }: { entity: Entity }) => (
 ```yaml
 metadata:
   annotations:
-    jira/project-key: [example-jira-project-key]
-    jira/component: [example-component] // optional, you might skip value to fetch data for all components
+    jira/project-key: <example-jira-project-key>
+    jira/component: <example-component> # optional, you might skip value to fetch data for all components
 ```
 
 2. Get and provide `JIRA_TOKEN` as env variable in following format:
    "Basic base64(jira-mail@example.com:JIRA_TOKEN)" for example:
-   `Basic: ZXhhbXBsZV9qaXJhQGV4YW1wbGUuY29tOjU1Q3NUSEoxWW1oTVdJSFptdGJXNUUxOA==`
+   `Basic ZXhhbXBsZV9qaXJhQGV4YW1wbGUuY29tOjU1Q3NUSEoxWW1oTVdJSFptdGJXNUUxOA==`
 
 ## Links
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,7 +23,7 @@ export const jiraApiRef = createApiRef<JiraAPI>({
   description: 'Used by the Jira plugin to make requests',
 });
 
-const DEFAULT_PROXY_PATH = '/jira/api/';
+const DEFAULT_PROXY_PATH = '/jira/api';
 const DEFAULT_REST_API_VERSION = 3;
 
 type Options = {
@@ -139,7 +139,7 @@ export class JiraAPI {
   async getActivityStream(size: number, projectKey: string) {
     const { baseUrl } = await this.getUrls();
     const request = await axios.get(
-      `${baseUrl}activity?maxResults=${size}&streams=key+IS+${projectKey}&os_authType=basic`,
+      `${baseUrl}/activity?maxResults=${size}&streams=key+IS+${projectKey}&os_authType=basic`,
     );
     const activityStream = request.data;
     return activityStream;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -96,8 +96,8 @@ export class JiraAPI {
     statusesNames: Array<string>,
   ) {
     const { apiUrl } = await this.getUrls();
-    const request = await axios.get(`${apiUrl}project/${projectKey}`);
-    const project = request.data as Project;
+    const request = await axios.get<Project>(`${apiUrl}project/${projectKey}`);
+    const project = request.data;
 
     // Generate counters for each issue type
     const issuesTypes = project.issueTypes.map((status: IssueType) => ({

--- a/src/components/JiraCard/JiraCard.tsx
+++ b/src/components/JiraCard/JiraCard.tsx
@@ -115,7 +115,7 @@ export const JiraCard = ({ entity }: EntityProps) => {
           >
             <MenuItem onClick={changeType}>
               <Checkbox checked={type === 'all'} />
-              <>Show non-empty issue types</>
+              <>Show empty issue types</>
             </MenuItem>
           </Menu>
         </>

--- a/src/hooks/useEmptyIssueTypeFilter.ts
+++ b/src/hooks/useEmptyIssueTypeFilter.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 RoadieHQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useLocalStorage } from 'react-use';
+import { IssuesCounter } from '../types';
+
+export type IssuetypeType = 'non-empty' | 'all';
+
+export const useEmptyIssueTypeFilter = (
+  issueTypes: IssuesCounter[] | undefined,
+) => {
+  const [type, setType] = useLocalStorage<IssuetypeType>(
+    'jira-plugin-issuetype-filter',
+    'non-empty',
+  );
+
+  return {
+    issueTypes:
+      type === 'non-empty'
+        ? issueTypes?.filter(t => t.total !== 0)
+        : issueTypes,
+    type,
+    changeType:
+      type === 'non-empty' ? () => setType('all') : () => setType('non-empty'),
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src", "dev"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
Technically speaking, I could add an expanding panel with some label like "show empty issue types", but I wanted to maintain as much visual simplicity as i could - in the end it's an overview widget and it shouldn't be used to generate reports, rather get the most valuable piece of the info.

I've implemented showing non-empty ones by default and an ability to switch it by the user to "all". The setting will be stored in local storage so it wouldn't be necessary to toggle it every time user opens the browser.

https://www.loom.com/share/d652cf4430f840e3b78a8153676ea342