### PR TITLE
Fix actions button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-jira",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/JiraCard/JiraCard.test.tsx
+++ b/src/components/JiraCard/JiraCard.test.tsx
@@ -75,7 +75,7 @@ describe('JiraCard', () => {
     );
 
     expect(await rendered.findByText(/backstage-test/)).toBeInTheDocument();
-    expect(await rendered.findByText(/testComponent/)).toBeInTheDocument();
+    expect((await rendered.findAllByText(/testComponent/)).length).toBeGreaterThan(0);
     expect(
       await rendered.findByText(
         /changed the status to Selected for Development/,

--- a/src/components/JiraCard/JiraCard.tsx
+++ b/src/components/JiraCard/JiraCard.tsx
@@ -54,10 +54,6 @@ const useStyles = makeStyles((theme: Theme) =>
         marginTop: theme.spacing(1),
       },
     },
-    actions: {
-      // It's a workaroung for strange styles set in @backstage/core InfoCard component
-      margin: theme.spacing(-8, -8, 0, 0),
-    },
   }),
 );
 
@@ -68,7 +64,7 @@ const CardProjectDetails = ({
   project: ProjectDetailsProps;
   component: string;
 }) => (
-  <Box display="flex" alignItems="center">
+  <Box display="inline-flex" alignItems="center">
     <Avatar alt="" src={project.iconUrl} />
     <Box ml={1}>
       {project.name} | {project.type}
@@ -111,33 +107,32 @@ export const JiraCard = (_props: EntityProps) => {
       title="Jira"
       subheader={
         project && (
-          <CardProjectDetails project={project} component={component} />
+          <Box>
+            <CardProjectDetails project={project} component={component} />
+            <Box display="inline-flex" pl={1}>
+              <IconButton
+                aria-label="more"
+                aria-controls="long-menu"
+                aria-haspopup="true"
+                onClick={handleClick}
+              >
+                <MoreVertIcon />
+              </IconButton>
+              <Menu
+                id="simple-menu"
+                anchorEl={anchorEl}
+                keepMounted
+                open={Boolean(anchorEl)}
+                onClose={handleClose}
+              >
+                <MenuItem onClick={changeType}>
+                  <Checkbox checked={type === 'all'} />
+                  <>Show empty issue types</>
+                </MenuItem>
+              </Menu>
+            </Box>
+          </Box>
         )
-      }
-      actionsTopRight={
-        <>
-          <IconButton
-            className={classes.actions}
-            aria-label="more"
-            aria-controls="long-menu"
-            aria-haspopup="true"
-            onClick={handleClick}
-          >
-            <MoreVertIcon />
-          </IconButton>
-          <Menu
-            id="simple-menu"
-            anchorEl={anchorEl}
-            keepMounted
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
-          >
-            <MenuItem onClick={changeType}>
-              <Checkbox checked={type === 'all'} />
-              <>Show empty issue types</>
-            </MenuItem>
-          </Menu>
-        </>
       }
       deepLink={{
         link: `${project?.url}/browse/${projectKey}`,


### PR DESCRIPTION
The actions button in the JiraCard was displaying below the sub header when it should be on the same line to the right:

![actions-before](https://user-images.githubusercontent.com/14176917/118047796-3531d000-b373-11eb-84b9-1da2c253f8b1.png)

 It looks like the `actionsTopRight` prop of `InfoCard` could be broken, but I don't think it's needed anyway as I've just moved the elements for the button into the `subheader`:

![actions-after](https://user-images.githubusercontent.com/14176917/118047911-5d213380-b373-11eb-9ffa-7d9e9f412b14.png)

I also had to fix an unrelated test that was broken. Not sure how that happened but there are multiple elements with the text `testComponent` in the rendered document whereas the test was expecting 1.